### PR TITLE
Add workspace sweep module and UI

### DIFF
--- a/Raw Information/index_ayva_fixed.html
+++ b/Raw Information/index_ayva_fixed.html
@@ -469,6 +469,21 @@
         </details>
     </section>
 
+    <!-- Workspace sweep panel -->
+    <section class="panel" id="workspacePanel">
+        <h3>Workspace Sweep</h3>
+        <div class="vrow"><button id="runWorkspace">Run Sweep</button></div>
+        <div class="vrow">Coverage: <span id="coveragePct">0%</span></div>
+        <details>
+            <summary>Limit Violations</summary>
+            <ul id="violationsList" style="list-style:none; padding-left:0; margin:8px 0;"></ul>
+        </details>
+        <div class="vrow">
+            <button id="exportWorkspaceJson">Export JSON</button>
+            <button id="exportWorkspaceCsv">Export CSV</button>
+        </div>
+    </section>
+
     <!-- Keyboard control panel (shown when Keyboard pattern is selected) -->
     <section class="panel" id="keyboardPanel" style="display:none;">
         <h3>Keyboard</h3>
@@ -1597,6 +1612,47 @@ Stewart.prototype.initAyva = function (opts) {
                 animator.next = null;
             }
         };
+    </script>
+    <script type="module">
+        import { computeWorkspace, exportResults } from '../workspace.js';
+
+        const ranges = {
+            x: { min: -50, max: 50, step: 10 },
+            y: { min: -50, max: 50, step: 10 },
+            z: { min: -20, max: 20, step: 10 },
+            rx: { min: -10, max: 10, step: 5 },
+            ry: { min: -10, max: 10, step: 5 },
+            rz: { min: -10, max: 10, step: 5 },
+        };
+
+        let lastResult = null;
+        const runBtn = document.getElementById('runWorkspace');
+        const coverageEl = document.getElementById('coveragePct');
+        const violationsEl = document.getElementById('violationsList');
+
+        runBtn?.addEventListener('click', () => {
+            if (!window.platform) return;
+            lastResult = computeWorkspace(window.platform, ranges, {
+                payload: 1,
+                stroke: 10,
+                frequency: 1,
+                servoTorqueLimit: window.platform.servoTorqueLimit || Infinity,
+            });
+            coverageEl.textContent = (lastResult.coverage * 100).toFixed(1) + '%';
+            violationsEl.innerHTML = '';
+            lastResult.violations.forEach(v => {
+                const li = document.createElement('li');
+                li.textContent = v;
+                violationsEl.appendChild(li);
+            });
+        });
+
+        document.getElementById('exportWorkspaceJson')?.addEventListener('click', () => {
+            exportResults(lastResult, 'json');
+        });
+        document.getElementById('exportWorkspaceCsv')?.addEventListener('click', () => {
+            exportResults(lastResult, 'csv');
+        });
     </script>
 </body>
 

--- a/workspace.js
+++ b/workspace.js
@@ -1,0 +1,140 @@
+// Module to sweep workspace of a Stewart platform
+export function computeWorkspace(platform, ranges, options = {}) {
+  const {
+    payload = 0, // kg
+    stroke = 0, // mm
+    frequency = 0, // Hz
+    servoTorqueLimit = Infinity,
+    ballJointLimitDeg = 90
+  } = options;
+
+  const QuaternionObj = (typeof Quaternion !== 'undefined') ? Quaternion : options.Quaternion;
+  if (!platform || !QuaternionObj) {
+    throw new Error('platform and Quaternion are required');
+  }
+
+  const dist3 = (a, b) => {
+    const dx = a[0] - b[0];
+    const dy = a[1] - b[1];
+    const dz = a[2] - b[2];
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
+  };
+
+  const mapLoadToForce = () => {
+    // Simple dynamic model: payload shared by 6 legs plus inertial component
+    const mass = payload; // assume already kg
+    const accel = Math.pow(2 * Math.PI * frequency, 2) * (stroke / 1000); // m/s^2
+    return mass * (9.81 + accel) / 6; // force per leg (N)
+  };
+
+  const legForce = mapLoadToForce();
+  const torquePerForce = platform.hornLength || 1; // Nm per Newton
+
+  const reachable = [];
+  const failures = [];
+
+  const list = (axis) => {
+    const { min = 0, max = 0, step = 1 } = ranges[axis] || {};
+    const arr = [];
+    for (let v = min; v <= max + 1e-9; v += step) arr.push(v);
+    return arr;
+  };
+
+  const xs = list('x'), ys = list('y'), zs = list('z');
+  const rxs = list('rx'), rys = list('ry'), rzs = list('rz');
+
+  let total = 0;
+  for (const x of xs) {
+    for (const y of ys) {
+      for (const z of zs) {
+        for (const rx of rxs) {
+          for (const ry of rys) {
+            for (const rz of rzs) {
+              total++;
+              const pos = [x, y, z];
+              const q = QuaternionObj.fromEuler(
+                rx * Math.PI / 180,
+                ry * Math.PI / 180,
+                rz * Math.PI / 180,
+                'XYZ'
+              );
+              let ok = true;
+              let reason = '';
+              try {
+                const prevPos = platform.translation ? platform.translation.slice() : [0, 0, 0];
+                const prevQ = platform.orientation || QuaternionObj.ONE;
+                platform.update(pos, q);
+                const angles = platform.getServoAngles && platform.getServoAngles();
+                if (!angles || angles.some(a => a === null)) {
+                  ok = false; reason = 'IK';
+                }
+                if (ok && platform.servoRange) {
+                  for (const a of angles) {
+                    if (a < platform.servoRange[0] || a > platform.servoRange[1]) {
+                      ok = false; reason = 'servo range'; break;
+                    }
+                  }
+                }
+                if (ok && platform.B && platform.H && platform.hornLength) {
+                  const tol = Math.max(1e-3 * platform.hornLength, 0.5);
+                  for (let i = 0; i < platform.H.length; i++) {
+                    if (dist3(platform.H[i], platform.B[i]) > platform.hornLength + tol) {
+                      ok = false; reason = 'horn stretch'; break;
+                    }
+                  }
+                }
+                if (ok) {
+                  const torque = legForce * torquePerForce;
+                  if (torque > servoTorqueLimit) {
+                    ok = false; reason = 'torque';
+                  }
+                }
+                platform.update(prevPos, prevQ);
+              } catch (e) {
+                ok = false; reason = 'error';
+              }
+
+              const pose = { x, y, z, rx, ry, rz };
+              if (ok) {
+                reachable.push(pose);
+                console.log('reachable', pose);
+              } else {
+                failures.push({ pose, reason });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  const coverage = total ? reachable.length / total : 0;
+  const violations = failures.map(f => f.reason);
+  return { coverage, violations, reachable, unreachable: failures };
+}
+
+export function exportResults(result, format = 'json') {
+  if (!result) return;
+  let data = '';
+  let mime = '';
+  if (format === 'json') {
+    data = JSON.stringify(result, null, 2);
+    mime = 'application/json';
+  } else if (format === 'csv') {
+    const rows = [['x','y','z','rx','ry','rz','ok','reason']];
+    const add = (p, ok, reason='') => rows.push([p.x,p.y,p.z,p.rx,p.ry,p.rz,ok,reason]);
+    result.reachable.forEach(p => add(p, true));
+    result.unreachable.forEach(f => add(f.pose, false, f.reason));
+    data = rows.map(r => r.join(',')).join('\n');
+    mime = 'text/csv';
+  }
+  const blob = new Blob([data], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'workspace.' + (format === 'json' ? 'json' : 'csv');
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- add `workspace.js` module to sweep pose ranges, check torque limits, and export results
- integrate workspace sweep controls into existing UI, exposing coverage and limit violations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bcdfebda2c8331bcb313fddc7222de