### PR TITLE
fix: reference old project scripts

### DIFF
--- a/Raw Information/index_ayva_fixed.html
+++ b/Raw Information/index_ayva_fixed.html
@@ -568,9 +568,9 @@
     </section>
 
     <!-- Libraries -->
-    <script src="js/p5.min.js"></script>
-    <script src="js/quaternion.min.js"></script>
-    <script src="js/stewart.min.js"></script>
+    <script src="Stuff from Old Project/p5.min.js"></script>
+    <script src="Stuff from Old Project/quaternion.min.js"></script>
+    <script src="Stuff from Old Project/stewart.min.js"></script>
 
     <script>
         // ---------- State ----------


### PR DESCRIPTION
## Summary
- reference p5, quaternion, and stewart libs from "Stuff from Old Project"

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68bd2418e0188331b2206a6fb95d05fc