### PR TITLE
Fix AYVA layout initialization and expose platform for workspace sweeps

### DIFF
--- a/Raw Information/index_ayva_fixed.html
+++ b/Raw Information/index_ayva_fixed.html
@@ -898,43 +898,75 @@
         };
         new p5(sketch);
 
-        
+
+Stewart.prototype.initCustom = function (layout) {
+    this.rodLength = layout.rod_length;
+    this.hornLength = layout.horn_length;
+    this.servoRange = (layout.servo_range || [-90, 90]).map(d => d * Math.PI / 180);
+
+    this.B = [];
+    this.P = [];
+    this.q = [];
+    this.l = [];
+    this.H = [];
+    this.e = [];
+    this.f = [];
+    this.g = [];
+    this.sinBeta = [];
+    this.cosBeta = [];
+
+    for (let i = 0; i < layout.base_anchors.length; i++) {
+        this.B.push(layout.base_anchors[i]);
+        this.P.push(layout.platform_anchors[i]);
+        this.sinBeta.push(Math.sin(layout.beta_angles[i]));
+        this.cosBeta.push(Math.cos(layout.beta_angles[i]));
+        this.q.push([0, 0, 0]);
+        this.l.push([0, 0, 0]);
+        this.H.push([0, 0, 0]);
+        this.e.push(0);
+        this.f.push(0);
+        this.g.push(0);
+    }
+
+    this.T0 = [0, 0, Math.sqrt(
+        this.rodLength * this.rodLength + this.hornLength * this.hornLength -
+        Math.pow(this.P[0][0] - this.B[0][0], 2) -
+        Math.pow(this.P[0][1] - this.B[0][1], 2)
+    )];
+
+    this.drawBasePlate = function () { };
+    this.drawPlatformPlate = function () { };
+    this.servoRangeVisible = false;
+};
+
 Stewart.prototype.initAyva = function (opts) {
     const baseX = opts.baseXOffset || 60;
     const ySpacing = opts.ySpacing || 40;
     const platX = opts.platformXOffset || 30;
-
-    this.B = [];
-    this.P = [];
-    this.beta = [];
+    const hornLength = opts.hornLength || 50;
+    const rodLength = opts.rodLength || 150;
+    const servoRange = opts.servoRange || [-Math.PI / 2, Math.PI / 2];
 
     const yOffsets = [-ySpacing, 0, ySpacing];
+    const baseAnchors = [];
+    const platformAnchors = [];
     for (let y of yOffsets) {
-        this.B.push([-baseX, y, 0]);
-        this.P.push([-platX, y, 0]);
-        this.beta.push(0);
-
-        this.B.push([ baseX, y, 0]);
-        this.P.push([ platX, y, 0]);
-        this.beta.push(0);
+        baseAnchors.push([-baseX, y, 0]);
+        platformAnchors.push([-platX, y, 0]);
+        baseAnchors.push([ baseX, y, 0]);
+        platformAnchors.push([ platX, y, 0]);
     }
 
-    this.hornLength = opts.hornLength || 50;
-    this.rodLength = opts.rodLength || 150;
+    const layout = {
+        base_anchors: baseAnchors,
+        platform_anchors: platformAnchors,
+        beta_angles: [0, 0, 0, 0, 0, 0],
+        horn_length: hornLength,
+        rod_length: rodLength,
+        servo_range: servoRange.map(r => r * 180 / Math.PI)
+    };
 
-    // Dummy outlines for rendering
-    this.baseOutline = [
-        [-baseX-20, -ySpacing-20, 0],
-        [ baseX+20, -ySpacing-20, 0],
-        [ baseX+20,  ySpacing+20, 0],
-        [-baseX-20,  ySpacing+20, 0]
-    ];
-    this.platformOutline = [
-        [-platX-20, -ySpacing-20, 0],
-        [ platX+20, -ySpacing-20, 0],
-        [ platX+20,  ySpacing+20, 0],
-        [-platX-20,  ySpacing+20, 0]
-    ];
+    this.initCustom(layout);
 };
 
         // ---------- Platform & Animator ----------
@@ -946,6 +978,7 @@ Stewart.prototype.initAyva = function (opts) {
         platform.initHexagonal(opts);
     }
             if (Array.isArray(opts.servoRange)) platform.servoRange = opts.servoRange.slice();
+            window.platform = platform;
 
             // Stewart.Animation for RAW‑exact motion
             animator = new Stewart.Animation(platform);


### PR DESCRIPTION
## Summary
- Define generic `initCustom` method so layouts can initialize without relying on built-in hex/circle helpers
- Have AYVA initializer call the shared custom-layout builder to prevent blank canvas and make Workspace Sweep usable

## Testing
- `node -e "import('./workspace.js').then(m=>console.log('workspace loaded', Object.keys(m)));" --experimental-modules`


------
https://chatgpt.com/codex/tasks/task_b_68bcc53a661483319478bc5312db7fa9