### PR TITLE
Compute servo angles from general beta expressions

### DIFF
--- a/workspace.js
+++ b/workspace.js
@@ -64,16 +64,9 @@ export function computeWorkspace(platform, ranges, options = {}) {
                 const prevPos = platform.translation ? platform.translation.slice() : [0, 0, 0];
                 const prevQ = platform.orientation || QuaternionObj.ONE;
                 platform.update(pos, q);
-                const angles = platform.getServoAngles && platform.getServoAngles();
+                const angles = platform.servoAngles;
                 if (!angles || angles.some(a => a === null)) {
-                  ok = false; reason = 'IK';
-                }
-                if (ok && platform.servoRange) {
-                  for (const a of angles) {
-                    if (a < platform.servoRange[0] || a > platform.servoRange[1]) {
-                      ok = false; reason = 'servo range'; break;
-                    }
-                  }
+                  ok = false; reason = 'servo range';
                 }
                 if (ok && platform.B && platform.H && platform.hornLength) {
                   const tol = Math.max(1e-3 * platform.hornLength, 0.5);
@@ -97,7 +90,6 @@ export function computeWorkspace(platform, ranges, options = {}) {
               const pose = { x, y, z, rx, ry, rz };
               if (ok) {
                 reachable.push(pose);
-                console.log('reachable', pose);
               } else {
                 failures.push({ pose, reason });
               }


### PR DESCRIPTION
## Summary
- track servo angles and out-of-range legs on the Stewart platform
- derive each leg's servo angle using \( \alpha_k = \arcsin\frac{g_k}{\sqrt{e_k^2+f_k^2}} - \operatorname{atan2}(f_k,e_k) \)
- expose servo angles to workspace analysis for kinematics checks
- clamp servo angle calculations and drop verbose workspace logging

## Testing
- `node --check 'Raw Information/Stuff from Old Project/stewart.js'`
- `node --check workspace.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd87f6d01c8331bda6e1a49da1e18d