### PR TITLE
feat: sweep workspace and report mechanical limits

### DIFF
--- a/Raw Information/index_ayva_fixed.html
+++ b/Raw Information/index_ayva_fixed.html
@@ -1673,7 +1673,8 @@ Stewart.prototype.initAyva = function (opts) {
                     violationsEl.innerHTML = '';
                     lastResult.violations.forEach(v => {
                         const li = document.createElement('li');
-                        li.textContent = v;
+                        const txt = v.count ? `${v.reason} (${v.count})` : v.reason;
+                        li.textContent = txt;
                         violationsEl.appendChild(li);
                     });
                 });

--- a/workspace.js
+++ b/workspace.js
@@ -32,6 +32,7 @@ export function computeWorkspace(platform, ranges, options = {}) {
 
   const reachable = [];
   const failures = [];
+  const violationCounts = {};
 
   const list = (axis) => {
     const { min = 0, max = 0, step = 1 } = ranges[axis] || {};
@@ -83,6 +84,26 @@ export function computeWorkspace(platform, ranges, options = {}) {
                     }
                   }
                 }
+                if (ok && platform.B && platform.H && platform.P) {
+                  const toDeg = (rad) => rad * 180 / Math.PI;
+                  for (let i = 0; i < platform.P.length; i++) {
+                    const hornVec = [
+                      platform.H[i][0] - platform.B[i][0],
+                      platform.H[i][1] - platform.B[i][1],
+                      platform.H[i][2] - platform.B[i][2]
+                    ];
+                    const rodVec = [
+                      platform.P[i][0] - platform.H[i][0],
+                      platform.P[i][1] - platform.H[i][1],
+                      platform.P[i][2] - platform.H[i][2]
+                    ];
+                    const dot = hornVec[0] * rodVec[0] + hornVec[1] * rodVec[1] + hornVec[2] * rodVec[2];
+                    const magH = Math.sqrt(hornVec[0] ** 2 + hornVec[1] ** 2 + hornVec[2] ** 2);
+                    const magR = Math.sqrt(rodVec[0] ** 2 + rodVec[1] ** 2 + rodVec[2] ** 2);
+                    const angle = toDeg(Math.acos(Math.min(Math.max(dot / (magH * magR), -1), 1)));
+                    if (angle > ballJointLimitDeg) { ok = false; reason = 'ball joint'; break; }
+                  }
+                }
                 if (ok) {
                   const torque = legForce * torquePerForce;
                   if (torque > servoTorqueLimit) {
@@ -100,6 +121,7 @@ export function computeWorkspace(platform, ranges, options = {}) {
                 console.log('reachable', pose);
               } else {
                 failures.push({ pose, reason });
+                violationCounts[reason] = (violationCounts[reason] || 0) + 1;
               }
             }
           }
@@ -109,7 +131,7 @@ export function computeWorkspace(platform, ranges, options = {}) {
   }
 
   const coverage = total ? reachable.length / total : 0;
-  const violations = failures.map(f => f.reason);
+  const violations = Object.entries(violationCounts).map(([reason, count]) => ({ reason, count }));
   return { coverage, violations, reachable, unreachable: failures };
 }
 


### PR DESCRIPTION
## Summary
- check ball-joint angles when sweeping the Stewart platform workspace
- count limit violations and return coverage and pose lists
- surface coverage and violations in the UI with JSON/CSV export hooks

## Testing
- `node --input-type=module -e "import('./workspace.js').then(({computeWorkspace})=>{class Q{static fromEuler(){return{};} static get ONE(){return{};}} const p={translation:[0,0,0],orientation:Q.ONE,hornLength:1,servoRange:[-90,90],B:Array(6).fill([0,0,0]),H:Array(6).fill([1,0,0]),P:Array(6).fill([2,0,0]),update(){},getServoAngles(){return Array(6).fill(0);}}; const ranges={x:{min:0,max:0,step:1},y:{min:0,max:0,step:1},z:{min:0,max:0,step:1},rx:{min:0,max:0,step:1},ry:{min:0,max:0,step:1},rz:{min:0,max:0,step:1}}; console.log(computeWorkspace(p,ranges,{Quaternion:Q})); })"`

------
https://chatgpt.com/codex/tasks/task_b_68bd87f8831c833182d15553298ea5a3