### PR TITLE
Fix broken library paths for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -599,9 +599,9 @@
     </section>
 
     <!-- Libraries -->
-    <script src="Stuff from Old Project/p5.min.js"></script>
-    <script src="Stuff from Old Project/quaternion.min.js"></script>
-    <script src="Stuff from Old Project/stewart.min.js"></script>
+    <script src="Raw Information/Stuff from Old Project/p5.min.js"></script>
+    <script src="Raw Information/Stuff from Old Project/quaternion.min.js"></script>
+    <script src="Raw Information/Stuff from Old Project/stewart.min.js"></script>
 
     <script>
         // ---------- State ----------


### PR DESCRIPTION
## Summary
- correct script paths for p5, quaternion, and stewart libraries so GitHub Pages can load them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68c5e7fb91a083319d1ad0f62703b70b