### PR TITLE
Rename layout toggle for clarity

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
         </div>
         
         <div class="vrow">
-            <label><input type="checkbox" id="ayvaLayoutCheckbox"> Use AYVA Layout</label>
+            <label><input type="checkbox" id="linearLayoutCheckbox"> Use linear layout</label>
         </div>
             <div class="lrow"><label for="shaftDistanceSlider">Shaft Distance (mm)</label><input type="range"
                 id="shaftDistanceSlider" min="0" max="120" value="30"><input class="num" type="number"
@@ -1012,7 +1012,7 @@ Stewart.prototype.initAyva = function (opts) {
         // ---------- Platform & Animator ----------
         async function rebuildPlatform() {
             platform = new Stewart();
-            if (document.getElementById("ayvaLayoutCheckbox") && document.getElementById("ayvaLayoutCheckbox").checked) {
+            if (document.getElementById("linearLayoutCheckbox") && document.getElementById("linearLayoutCheckbox").checked) {
                 const layout = await loadAyvaLayout();
                 platform.initCustom(layout);
             } else {


### PR DESCRIPTION
## Summary
- Clarify mechanical panel switch by renaming 'Use AYVA Layout' to 'Use linear layout'
- Update platform rebuild logic to reference new `linearLayoutCheckbox` id

## Testing
- `node --check optimizer.js`
- `node --check workspace.js`
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_b_68c5f37f48e48331ba9ccef367614a34