### PR TITLE
Allow step size configuration for workspace optimization

### DIFF
--- a/Raw Information/index_linear_example.html
+++ b/Raw Information/index_linear_example.html
@@ -491,22 +491,22 @@
             <label class="inline"><span>Generations</span><input class="num" id="optGenerations" type="number" min="1" value="10"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>X Range (mm)</span><input class="num" id="optXMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optXMax" type="number" value="50"></label>
+            <label class="inline"><span>X Range (mm)</span><input class="num" id="optXMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optXMax" type="number" value="50"><span class="muted">step</span><input class="num" id="optXStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Y Range (mm)</span><input class="num" id="optYMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optYMax" type="number" value="50"></label>
+            <label class="inline"><span>Y Range (mm)</span><input class="num" id="optYMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optYMax" type="number" value="50"><span class="muted">step</span><input class="num" id="optYStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Z Range (mm)</span><input class="num" id="optZMin" type="number" value="-20"><span class="muted">to</span><input class="num" id="optZMax" type="number" value="20"></label>
+            <label class="inline"><span>Z Range (mm)</span><input class="num" id="optZMin" type="number" value="-20"><span class="muted">to</span><input class="num" id="optZMax" type="number" value="20"><span class="muted">step</span><input class="num" id="optZStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Rx Range (°)</span><input class="num" id="optRxMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRxMax" type="number" value="10"></label>
+            <label class="inline"><span>Rx Range (°)</span><input class="num" id="optRxMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRxMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRxStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Ry Range (°)</span><input class="num" id="optRyMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRyMax" type="number" value="10"></label>
+            <label class="inline"><span>Ry Range (°)</span><input class="num" id="optRyMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRyMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRyStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Rz Range (°)</span><input class="num" id="optRzMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRzMax" type="number" value="10"></label>
+            <label class="inline"><span>Rz Range (°)</span><input class="num" id="optRzMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRzMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRzStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
             <button id="runOptimization">Run Optimization</button>
@@ -1744,12 +1744,36 @@ Stewart.prototype.initLinear = function (opts) {
             const { Optimizer } = await ensureOptimizerModule();
             const gens = parseInt(document.getElementById('optGenerations').value, 10) || 10;
             const ranges = {
-                x: { min: parseFloat(document.getElementById('optXMin').value), max: parseFloat(document.getElementById('optXMax').value) },
-                y: { min: parseFloat(document.getElementById('optYMin').value), max: parseFloat(document.getElementById('optYMax').value) },
-                z: { min: parseFloat(document.getElementById('optZMin').value), max: parseFloat(document.getElementById('optZMax').value) },
-                rx: { min: parseFloat(document.getElementById('optRxMin').value), max: parseFloat(document.getElementById('optRxMax').value) },
-                ry: { min: parseFloat(document.getElementById('optRyMin').value), max: parseFloat(document.getElementById('optRyMax').value) },
-                rz: { min: parseFloat(document.getElementById('optRzMin').value), max: parseFloat(document.getElementById('optRzMax').value) },
+                x: {
+                    min: parseFloat(document.getElementById('optXMin').value),
+                    max: parseFloat(document.getElementById('optXMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optXStep').value)) || 5
+                },
+                y: {
+                    min: parseFloat(document.getElementById('optYMin').value),
+                    max: parseFloat(document.getElementById('optYMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optYStep').value)) || 5
+                },
+                z: {
+                    min: parseFloat(document.getElementById('optZMin').value),
+                    max: parseFloat(document.getElementById('optZMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optZStep').value)) || 5
+                },
+                rx: {
+                    min: parseFloat(document.getElementById('optRxMin').value),
+                    max: parseFloat(document.getElementById('optRxMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRxStep').value)) || 5
+                },
+                ry: {
+                    min: parseFloat(document.getElementById('optRyMin').value),
+                    max: parseFloat(document.getElementById('optRyMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRyStep').value)) || 5
+                },
+                rz: {
+                    min: parseFloat(document.getElementById('optRzMin').value),
+                    max: parseFloat(document.getElementById('optRzMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRzStep').value)) || 5
+                },
             };
             currentOptimizer = new Optimizer(window.platform, { generations: gens, ranges });
             const update = () => {

--- a/index.html
+++ b/index.html
@@ -493,22 +493,22 @@
             <label class="inline"><span>Generations</span><input class="num" id="optGenerations" type="number" min="1" value="10"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>X Range (mm)</span><input class="num" id="optXMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optXMax" type="number" value="50"></label>
+            <label class="inline"><span>X Range (mm)</span><input class="num" id="optXMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optXMax" type="number" value="50"><span class="muted">step</span><input class="num" id="optXStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Y Range (mm)</span><input class="num" id="optYMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optYMax" type="number" value="50"></label>
+            <label class="inline"><span>Y Range (mm)</span><input class="num" id="optYMin" type="number" value="-50"><span class="muted">to</span><input class="num" id="optYMax" type="number" value="50"><span class="muted">step</span><input class="num" id="optYStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Z Range (mm)</span><input class="num" id="optZMin" type="number" value="-20"><span class="muted">to</span><input class="num" id="optZMax" type="number" value="20"></label>
+            <label class="inline"><span>Z Range (mm)</span><input class="num" id="optZMin" type="number" value="-20"><span class="muted">to</span><input class="num" id="optZMax" type="number" value="20"><span class="muted">step</span><input class="num" id="optZStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Rx Range (°)</span><input class="num" id="optRxMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRxMax" type="number" value="10"></label>
+            <label class="inline"><span>Rx Range (°)</span><input class="num" id="optRxMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRxMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRxStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Ry Range (°)</span><input class="num" id="optRyMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRyMax" type="number" value="10"></label>
+            <label class="inline"><span>Ry Range (°)</span><input class="num" id="optRyMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRyMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRyStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
-            <label class="inline"><span>Rz Range (°)</span><input class="num" id="optRzMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRzMax" type="number" value="10"></label>
+            <label class="inline"><span>Rz Range (°)</span><input class="num" id="optRzMin" type="number" value="-10"><span class="muted">to</span><input class="num" id="optRzMax" type="number" value="10"><span class="muted">step</span><input class="num" id="optRzStep" type="number" value="5"></label>
         </div>
         <div class="vrow">
             <button id="runOptimization">Run Optimization</button>
@@ -1817,12 +1817,36 @@ Stewart.prototype.initAyva = function (opts) {
             const { Optimizer } = await ensureOptimizerModule();
             const gens = parseInt(document.getElementById('optGenerations').value, 10) || 10;
             const ranges = {
-                x: { min: parseFloat(document.getElementById('optXMin').value), max: parseFloat(document.getElementById('optXMax').value) },
-                y: { min: parseFloat(document.getElementById('optYMin').value), max: parseFloat(document.getElementById('optYMax').value) },
-                z: { min: parseFloat(document.getElementById('optZMin').value), max: parseFloat(document.getElementById('optZMax').value) },
-                rx: { min: parseFloat(document.getElementById('optRxMin').value), max: parseFloat(document.getElementById('optRxMax').value) },
-                ry: { min: parseFloat(document.getElementById('optRyMin').value), max: parseFloat(document.getElementById('optRyMax').value) },
-                rz: { min: parseFloat(document.getElementById('optRzMin').value), max: parseFloat(document.getElementById('optRzMax').value) },
+                x: {
+                    min: parseFloat(document.getElementById('optXMin').value),
+                    max: parseFloat(document.getElementById('optXMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optXStep').value)) || 5
+                },
+                y: {
+                    min: parseFloat(document.getElementById('optYMin').value),
+                    max: parseFloat(document.getElementById('optYMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optYStep').value)) || 5
+                },
+                z: {
+                    min: parseFloat(document.getElementById('optZMin').value),
+                    max: parseFloat(document.getElementById('optZMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optZStep').value)) || 5
+                },
+                rx: {
+                    min: parseFloat(document.getElementById('optRxMin').value),
+                    max: parseFloat(document.getElementById('optRxMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRxStep').value)) || 5
+                },
+                ry: {
+                    min: parseFloat(document.getElementById('optRyMin').value),
+                    max: parseFloat(document.getElementById('optRyMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRyStep').value)) || 5
+                },
+                rz: {
+                    min: parseFloat(document.getElementById('optRzMin').value),
+                    max: parseFloat(document.getElementById('optRzMax').value),
+                    step: Math.abs(parseFloat(document.getElementById('optRzStep').value)) || 5
+                },
             };
             currentOptimizer = new Optimizer(window.platform, { generations: gens, ranges, ballJointLimitDeg, ballJointClamp: ballJointClampEnabled });
             const update = () => {

--- a/workspace.js
+++ b/workspace.js
@@ -37,9 +37,11 @@ export async function computeWorkspace(platform, ranges, options = {}) {
   const violationCounts = {};
 
   const list = (axis) => {
-    const { min = 0, max = 0, step = 1 } = ranges[axis] || {};
+    const { min = 0, max = 0, step } = ranges[axis] || {};
+    const defaultStep = axis.startsWith('r') ? 5 : 5; // 5° or 5 mm
+    const s = step > 0 ? step : defaultStep;
     const arr = [];
-    for (let v = min; v <= max + 1e-9; v += step) arr.push(v);
+    for (let v = min; v <= max + 1e-9; v += s) arr.push(v);
     return arr;
   };
 


### PR DESCRIPTION
## Summary
- Add step size fields to optimization UI for all translation and rotation axes
- Forward step values to Optimizer ranges and default to 5 units when unspecified
- Default workspace sweep iteration to 5 mm/5° steps when none provided

## Testing
- `node --input-type=module <<'NODE'
import { Optimizer } from './optimizer.js';

class SimpleQuaternion {
  static fromEuler(){ return new SimpleQuaternion(); }
  rotateVector(v){ return v; }
}
SimpleQuaternion.ONE = new SimpleQuaternion();
globalThis.Quaternion = SimpleQuaternion;

const platform = {
  layout: {},
  hornLength: 1,
  translation: [0,0,0],
  orientation: SimpleQuaternion.ONE,
  update(pos, q){ this.translation = pos; this.orientation = q; },
  computeAngles(){ return Array(6).fill(0); }
};

const ranges = {
  x: { min: -10, max: 10, step: 5 },
  y: { min: -10, max: 10, step: 5 },
  z: { min: -10, max: 10, step: 5 },
  rx: { min: 0, max: 0, step: 5 },
  ry: { min: 0, max: 0, step: 5 },
  rz: { min: 0, max: 0, step: 5 }
};

const opt = new Optimizer(platform, { populationSize: 2, generations: 1, ranges });
opt.initialize();
await opt.step();
console.log('Generation', opt.generation, 'fitness length', opt.fitness.length);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68c63ddc65d483319a601dc2a827da4a