### PR TITLE
Port workspace and optimizer logic to Rust with tests

### DIFF
--- a/stewart_sim/Cargo.lock
+++ b/stewart_sim/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1154,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "glam"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333928d5eb103c5d4050533cec0384302db6be8ef7d3cebd30ec6a35350353da"
+
+[[package]]
+name = "glam"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abb554f8ee44336b72d522e0a7fe86a29e09f839a36022fa869a7dfe941a54b"
+
+[[package]]
+name = "glam"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4126c0479ccf7e8664c36a2d719f5f2c140fbb4f9090008098d2c291fa5b3f16"
+
+[[package]]
+name = "glam"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01732b97afd8508eee3333a541b9f7610f454bb818669e66e90f5f57c93a776"
+
+[[package]]
+name = "glam"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525a3e490ba77b8e326fb67d4b44b4bd2f920f44d4cc73ccec50adc68e3bee34"
+
+[[package]]
+name = "glam"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b8509e6791516e81c1a630d0bd7fbac36d2fa8712a9da8662e716b52d5051ca"
+
+[[package]]
+name = "glam"
+version = "0.20.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43e957e744be03f5801a55472f593d43fabdebf25a4585db250f04d86b1675f"
+
+[[package]]
+name = "glam"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "518faa5064866338b013ff9b2350dc318e14cc4fcd6cb8206d7e7c9886c98815"
+
+[[package]]
+name = "glam"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f597d56c1bd55a811a1be189459e8fad2bbc272616375602443bdfb37fa774"
+
+[[package]]
+name = "glam"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4afd9ad95555081e109fe1d21f2a30c691b5f0919c67dfa690a2e1eb6bd51c"
+
+[[package]]
+name = "glam"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5418c17512bdf42730f9032c74e1ae39afc408745ebb2acf72fbc4691c17945"
+
+[[package]]
+name = "glam"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "151665d9be52f9bb40fc7966565d39666f2d1e69233571b71b87791c7e0528b3"
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
+
+[[package]]
+name = "glam"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779ae4bf7e8421cf91c0b3b64e7e8b40b862fba4d393f59150042de7c4965a94"
+
+[[package]]
+name = "glam"
+version = "0.29.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8babf46d4c1c9d92deac9f7be466f76dfc4482b6452fc5024b5e8daf6ffeb3ee"
+
+[[package]]
+name = "glam"
+version = "0.30.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2d1aab06663bdce00d6ca5e5ed586ec8d18033a771906c993a1e3755b368d85"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1554,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1590,6 +1701,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +1795,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd59afb6639828b33677758314a4a1a745c15c02bc597095b851c8fd915cf49"
+dependencies = [
+ "approx",
+ "glam 0.14.0",
+ "glam 0.15.2",
+ "glam 0.16.0",
+ "glam 0.17.3",
+ "glam 0.18.0",
+ "glam 0.19.0",
+ "glam 0.20.5",
+ "glam 0.21.3",
+ "glam 0.22.0",
+ "glam 0.23.0",
+ "glam 0.24.2",
+ "glam 0.25.0",
+ "glam 0.27.0",
+ "glam 0.28.0",
+ "glam 0.29.3",
+ "glam 0.30.5",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1894,45 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2171,6 +2374,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "piston-float"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad78bf43dcf80e8f950c92b84f938a0fc7590b7f6866fbcbeca781609c115590"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2428,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2473,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "quaternion"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a23cd933813dea6a8e24391c80634deba6a70ca5a14b2b944b8cb6d871e071"
+dependencies = [
+ "vecmath",
 ]
 
 [[package]]
@@ -2298,6 +2525,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2564,12 @@ name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2378,6 +2640,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,9 +2690,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.222"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab69e3f5be1836a1fe0aca0b286e5a5b38f262d6c9e8acd2247818751fcc8fb"
+checksum = "a505d71960adde88e293da5cb5eda57093379f64e61cf77bf0e6a63af07a7bac"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2423,22 +2700,35 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.222"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8ebec5eea07db7df9342aa712db2138f019d9ab3454a60a680579a6f841b80"
+checksum = "20f57cbd357666aa7b3ac84a90b4ea328f1d4ddb6772b430caa5d9e1309bb9e9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.222"
+version = "1.0.223"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5f61630fe26d0ff555e6c37dc445ab2f15871c8a11ace3cf471b3195d3e4f49"
+checksum = "3d428d07faf17e306e699ec1e91996e5a165ba5d6bce5b5155173e91a8a01a56"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2465,6 +2755,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99284beb21666094ba2b75bbceda012e610f5479dfcc2d6e2426f53197ffd95"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -2565,6 +2868,11 @@ name = "stewart_sim"
 version = "0.1.0"
 dependencies = [
  "eframe",
+ "nalgebra",
+ "quaternion",
+ "rand",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2792,6 +3100,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
 name = "uds_windows"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,6 +3151,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "vecmath"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "956ae1e0d85bca567dee1dcf87fb1ca2e792792f66f87dced8381f99cd91156a"
+dependencies = [
+ "piston-float",
+]
 
 [[package]]
 name = "version_check"
@@ -3240,6 +3563,16 @@ dependencies = [
  "log",
  "thiserror 2.0.16",
  "web-sys",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/stewart_sim/Cargo.toml
+++ b/stewart_sim/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2024"
 
 [dependencies]
 eframe = "0.32"
+nalgebra = "0.34.0"
+quaternion = "2.0.0"
+rand = "0.9.2"
+serde = { version = "1.0.223", features = ["derive"] }
+serde_json = "1.0.145"

--- a/stewart_sim/src/lib.rs
+++ b/stewart_sim/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod workspace;
+pub mod optimizer;
+
+// re-export commonly used items
+pub use workspace::{compute_workspace, WorkspaceOptions, WorkspaceResult, Range, Ranges, Platform};
+pub use optimizer::Optimizer;

--- a/stewart_sim/src/optimizer.rs
+++ b/stewart_sim/src/optimizer.rs
@@ -1,0 +1,145 @@
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+
+use crate::workspace::{compute_workspace, Platform, Ranges, WorkspaceOptions, WorkspaceResult};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Layout {
+    pub horn_length: f64,
+    pub rod_length: f64,
+}
+
+/// A platform that can be reconfigured by applying a layout.
+pub trait ConfigurablePlatform: Platform {
+    fn apply_layout(&mut self, layout: &Layout);
+    fn layout(&self) -> Layout;
+}
+
+/// Simple genetic optimizer translating logic from optimizer.js
+pub struct Optimizer<P: ConfigurablePlatform> {
+    pub platform: P,
+    pub ranges: Ranges,
+    pub options: WorkspaceOptions,
+    pub population_size: usize,
+    pub generations: usize,
+    pub mutation_rate: f64,
+    pub population: Vec<Layout>,
+    rng: rand::rngs::ThreadRng,
+}
+
+impl<P: ConfigurablePlatform> Optimizer<P> {
+    pub fn new(platform: P, ranges: Ranges, options: WorkspaceOptions, population_size: usize, generations: usize, mutation_rate: f64) -> Self {
+        Self {
+            platform,
+            ranges,
+            options,
+            population_size,
+            generations,
+            mutation_rate,
+            population: Vec::new(),
+            rng: rand::rng(),
+        }
+    }
+
+    fn randomize_layout(&mut self, base: &Layout) -> Layout {
+        let mut rand_val = |v: f64| v + (self.rng.random_range(0.0..1.0) * 2.0 - 1.0) * 5.0;
+        Layout { horn_length: rand_val(base.horn_length), rod_length: rand_val(base.rod_length) }
+    }
+
+    pub fn initialize(&mut self) {
+        let base = self.platform.layout();
+        self.population = (0..self.population_size).map(|_| self.randomize_layout(&base)).collect();
+    }
+
+    fn evaluate(&mut self, layout: &Layout) -> WorkspaceResult {
+        self.platform.apply_layout(layout);
+        compute_workspace(&mut self.platform, &self.ranges, self.options.clone())
+    }
+
+    fn mutate(&mut self, layout: &mut Layout) {
+        let mut rand_val = |v: &mut f64| {
+            if self.rng.random_range(0.0..1.0) < self.mutation_rate {
+                *v += (self.rng.random_range(0.0..1.0) * 2.0 - 1.0) * 5.0;
+            }
+        };
+        rand_val(&mut layout.horn_length);
+        rand_val(&mut layout.rod_length);
+    }
+
+    /// Execute one optimization step and return best layout found.
+    pub fn step(&mut self) -> Layout {
+        let population = self.population.clone();
+        let mut scored: Vec<(WorkspaceResult, Layout)> = population
+            .into_iter()
+            .map(|layout| (self.evaluate(&layout), layout))
+            .collect();
+        scored.sort_by(|a, b| b.0.coverage.partial_cmp(&a.0.coverage).unwrap());
+        let survivors: Vec<Layout> = scored
+            .iter()
+            .take(self.population_size / 2)
+            .map(|(_, l)| l.clone())
+            .collect();
+        let mut new_pop = survivors.clone();
+        while new_pop.len() < self.population_size {
+            let mut child = survivors[self.rng.random_range(0..survivors.len())].clone();
+            self.mutate(&mut child);
+            new_pop.push(child);
+        }
+        self.population = new_pop;
+        scored[0].1.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::{Platform, WorkspaceOptions};
+    use crate::Range;
+    use nalgebra::Vector3;
+    use quaternion as quat;
+
+    #[derive(Clone)]
+    struct DummyPlatform {
+        layout: Layout,
+        pos: Vector3<f64>,
+        q: quat::Quaternion<f64>,
+    }
+
+    impl DummyPlatform {
+        fn new() -> Self {
+            Self { layout: Layout { horn_length: 10.0, rod_length: 20.0 }, pos: Vector3::zeros(), q: quat::id() }
+        }
+    }
+
+    impl Platform for DummyPlatform {
+        fn update(&mut self, pos: Vector3<f64>, orient: quat::Quaternion<f64>) {
+            self.pos = pos;
+            self.q = orient;
+        }
+        fn compute_angles(&self) -> Option<Vec<f64>> { Some(vec![0.0; 6]) }
+        fn horn_length(&self) -> Option<f64> { Some(self.layout.horn_length) }
+        fn orientation(&self) -> quat::Quaternion<f64> { self.q }
+        fn translation(&self) -> Vector3<f64> { self.pos }
+    }
+
+    impl ConfigurablePlatform for DummyPlatform {
+        fn apply_layout(&mut self, layout: &Layout) { self.layout = layout.clone(); }
+        fn layout(&self) -> Layout { self.layout.clone() }
+    }
+
+    #[test]
+    fn optimizer_runs() {
+        let mut ranges = Ranges::new();
+        ranges.insert("x".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("y".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("z".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("rx".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("ry".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("rz".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        let options = WorkspaceOptions::default();
+        let platform = DummyPlatform::new();
+        let mut opt = Optimizer::new(platform, ranges, options, 4, 1, 0.1);
+        opt.initialize();
+        let _best = opt.step();
+    }
+}

--- a/stewart_sim/src/workspace.rs
+++ b/stewart_sim/src/workspace.rs
@@ -1,0 +1,306 @@
+use nalgebra::Vector3;
+use quaternion as quat;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Range for a single axis.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct Range {
+    pub min: f64,
+    pub max: f64,
+    pub step: f64,
+}
+
+impl Default for Range {
+    fn default() -> Self { Self { min: 0.0, max: 0.0, step: 0.0 } }
+}
+
+/// Options controlling workspace computation.
+#[derive(Clone, Debug)]
+pub struct WorkspaceOptions {
+    pub payload: f64,
+    pub stroke: f64,
+    pub frequency: f64,
+    pub servo_torque_limit: f64,
+    pub ball_joint_limit_deg: f64,
+    pub ball_joint_clamp: bool,
+}
+
+impl Default for WorkspaceOptions {
+    fn default() -> Self {
+        Self {
+            payload: 0.0,
+            stroke: 0.0,
+            frequency: 0.0,
+            servo_torque_limit: f64::INFINITY,
+            ball_joint_limit_deg: 90.0,
+            ball_joint_clamp: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Pose {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    pub rx: f64,
+    pub ry: f64,
+    pub rz: f64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Violation {
+    pub reason: String,
+    pub count: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Failure {
+    pub pose: Pose,
+    pub reason: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceResult {
+    pub coverage: f64,
+    pub violations: Vec<Violation>,
+    pub reachable: Vec<Pose>,
+    pub unreachable: Vec<Failure>,
+}
+
+/// HashMap based ranges keyed by axis name (e.g. "x", "rx").
+pub type Ranges = HashMap<String, Range>;
+
+/// Trait describing the minimal interface the workspace algorithm expects
+/// from a Stewart platform model.
+pub trait Platform {
+    fn update(&mut self, pos: Vector3<f64>, orient: quat::Quaternion<f64>);
+    fn compute_angles(&self) -> Option<Vec<f64>>;
+    fn servo_range(&self) -> Option<(f64, f64)> { None }
+    fn horn_length(&self) -> Option<f64> { None }
+    fn b_points(&self) -> Option<Vec<Vector3<f64>>> { None }
+    fn h_points(&self) -> Option<Vec<Vector3<f64>>> { None }
+    fn p_points(&self) -> Option<Vec<Vector3<f64>>> { None }
+    fn cos_beta(&self) -> Option<Vec<f64>> { None }
+    fn sin_beta(&self) -> Option<Vec<f64>> { None }
+    fn orientation(&self) -> quat::Quaternion<f64>;
+    fn translation(&self) -> Vector3<f64>;
+}
+
+fn map_load_to_force(payload: f64, stroke: f64, freq: f64) -> f64 {
+    let mass = payload;
+    let accel = (2.0 * std::f64::consts::PI * freq).powi(2) * (stroke / 1000.0);
+    mass * (9.81 + accel) / 6.0
+}
+
+fn list(ranges: &Ranges, axis: &str) -> Vec<f64> {
+    if let Some(r) = ranges.get(axis) {
+        let default_step = if axis.starts_with('r') { 5.0 } else { 5.0 };
+        let step = if r.step > 0.0 { r.step } else { default_step };
+        let mut arr = Vec::new();
+        let mut v = r.min;
+        while v <= r.max + 1e-9 {
+            arr.push(v);
+            v += step;
+        }
+        arr
+    } else {
+        vec![0.0]
+    }
+}
+
+fn dist3(a: &Vector3<f64>, b: &Vector3<f64>) -> f64 {
+    (a - b).norm()
+}
+
+fn rotate_vector(q: &quat::Quaternion<f64>, v: &Vector3<f64>) -> Vector3<f64> {
+    let arr = [v[0], v[1], v[2]];
+    let r = quat::rotate_vector(*q, arr);
+    Vector3::new(r[0], r[1], r[2])
+}
+
+/// Compute reachable workspace using a sweep over the provided ranges.
+pub fn compute_workspace<P: Platform>(
+    platform: &mut P,
+    ranges: &Ranges,
+    options: WorkspaceOptions,
+) -> WorkspaceResult {
+    let leg_force = map_load_to_force(options.payload, options.stroke, options.frequency);
+    let torque_per_force = platform.horn_length().unwrap_or(1.0);
+
+    let xs = list(ranges, "x");
+    let ys = list(ranges, "y");
+    let zs = list(ranges, "z");
+    let rxs = list(ranges, "rx");
+    let rys = list(ranges, "ry");
+    let rzs = list(ranges, "rz");
+
+    let total = xs.len() * ys.len() * zs.len() * rxs.len() * rys.len() * rzs.len();
+
+    let mut reachable = Vec::new();
+    let mut failures = Vec::new();
+    let mut violation_counts: HashMap<String, usize> = HashMap::new();
+
+    for &x in &xs {
+        for &y in &ys {
+            for &z in &zs {
+                for &rx in &rxs {
+                    for &ry in &rys {
+                        for &rz in &rzs {
+                            let pos = Vector3::new(x, y, z);
+                            let q = quat::euler_angles(
+                                rx.to_radians(),
+                                ry.to_radians(),
+                                rz.to_radians(),
+                            );
+                            let prev_pos = platform.translation();
+                            let prev_q = platform.orientation();
+                            let mut ok = true;
+                            let mut reason = String::new();
+                            platform.update(pos, q);
+
+                            match platform.compute_angles() {
+                                Some(angles) => {
+                                    if angles.iter().any(|a| a.is_nan()) {
+                                        ok = false;
+                                        reason = "IK".into();
+                                    } else if let Some((min, max)) = platform.servo_range() {
+                                        if angles.iter().any(|a| *a < min || *a > max) {
+                                            ok = false;
+                                            reason = "servo range".into();
+                                        }
+                                    }
+                                }
+                                None => {
+                                    ok = false;
+                                    reason = "IK".into();
+                                }
+                            }
+
+                            if ok {
+                                if let (Some(b), Some(h), Some(horn_len)) = (
+                                    platform.b_points(),
+                                    platform.h_points(),
+                                    platform.horn_length(),
+                                ) {
+                                    let tol = f64::max(1e-3 * horn_len, 0.5);
+                                    for (bi, hi) in b.iter().zip(h.iter()) {
+                                        if dist3(hi, bi) > horn_len + tol {
+                                            ok = false;
+                                            reason = "horn stretch".into();
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if ok && options.ball_joint_clamp {
+                                if let (Some(_b), Some(h), Some(p), Some(cb), Some(sb)) = (
+                                    platform.b_points(),
+                                    platform.h_points(),
+                                    platform.p_points(),
+                                    platform.cos_beta(),
+                                    platform.sin_beta(),
+                                ) {
+                                    let plat_normal = rotate_vector(&platform.orientation(), &Vector3::new(0.0, 0.0, 1.0));
+                                    for i in 0..p.len() {
+                                        let rod_vec = p[i] - h[i];
+                                        let mag = rod_vec.norm();
+                                        if mag == 0.0 {
+                                            continue;
+                                        }
+                                        let base_axis = Vector3::new(cb[i], sb[i], 0.0);
+                                        let cos_base = rod_vec.dot(&base_axis) / mag;
+                                        let cos_plat = rod_vec.dot(&plat_normal) / mag;
+                                        let ang_base = cos_base.abs().acos().to_degrees();
+                                        let ang_plat = cos_plat.abs().acos().to_degrees();
+                                        if ang_base > options.ball_joint_limit_deg
+                                            || ang_plat > options.ball_joint_limit_deg
+                                        {
+                                            ok = false;
+                                            reason = "ball joint".into();
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if ok {
+                                let torque = leg_force * torque_per_force;
+                                if torque > options.servo_torque_limit {
+                                    ok = false;
+                                    reason = "torque".into();
+                                }
+                            }
+
+                            platform.update(prev_pos, prev_q);
+
+                            let pose = Pose { x, y, z, rx, ry, rz };
+                            if ok {
+                                reachable.push(pose);
+                            } else {
+                                failures.push(Failure {
+                                    pose: pose.clone(),
+                                    reason: reason.clone(),
+                                });
+                                *violation_counts.entry(reason).or_insert(0) += 1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let coverage = if total > 0 { reachable.len() as f64 / total as f64 } else { 0.0 };
+    let violations = violation_counts
+        .into_iter()
+        .map(|(reason, count)| Violation { reason, count })
+        .collect();
+    WorkspaceResult { coverage, violations, reachable, unreachable: failures }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct DummyPlatform {
+        pos: Vector3<f64>,
+        q: quat::Quaternion<f64>,
+    }
+
+    impl DummyPlatform {
+        fn new() -> Self {
+            Self { pos: Vector3::zeros(), q: quat::id() }
+        }
+    }
+
+    impl Platform for DummyPlatform {
+        fn update(&mut self, pos: Vector3<f64>, orient: quat::Quaternion<f64>) {
+            self.pos = pos;
+            self.q = orient;
+        }
+        fn compute_angles(&self) -> Option<Vec<f64>> {
+            Some(vec![0.0; 6])
+        }
+        fn orientation(&self) -> quat::Quaternion<f64> { self.q }
+        fn translation(&self) -> Vector3<f64> { self.pos }
+    }
+
+    #[test]
+    fn simple_workspace() {
+        let mut platform = DummyPlatform::new();
+        let mut ranges = Ranges::new();
+        ranges.insert("x".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("y".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("z".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("rx".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("ry".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        ranges.insert("rz".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+        let result = compute_workspace(&mut platform, &ranges, WorkspaceOptions::default());
+        assert_eq!(result.coverage, 1.0);
+        assert_eq!(result.reachable.len(), 1);
+        assert!(result.unreachable.is_empty());
+    }
+}

--- a/stewart_sim/tests/js_workspace_call.mjs
+++ b/stewart_sim/tests/js_workspace_call.mjs
@@ -1,0 +1,13 @@
+import { computeWorkspace } from '../../workspace.js';
+const Quaternion = { fromEuler: () => ({ rotateVector: v => v }) };
+const platform = { update(){}, computeAngles(){ return [0,0,0,0,0,0]; } };
+const ranges = {
+  x:{min:0,max:0,step:1},
+  y:{min:0,max:0,step:1},
+  z:{min:0,max:0,step:1},
+  rx:{min:0,max:0,step:1},
+  ry:{min:0,max:0,step:1},
+  rz:{min:0,max:0,step:1}
+};
+const result = await computeWorkspace(platform, ranges, { Quaternion, ballJointClamp:false });
+console.log(JSON.stringify(result));

--- a/stewart_sim/tests/workspace_js_compare.rs
+++ b/stewart_sim/tests/workspace_js_compare.rs
@@ -1,0 +1,43 @@
+use std::process::Command;
+use stewart_sim::{compute_workspace, WorkspaceOptions, Range, Ranges, Platform};
+use serde_json::from_slice;
+use nalgebra::Vector3;
+use quaternion as quat;
+
+#[derive(Clone)]
+struct DummyPlatform {
+    pos: Vector3<f64>,
+    q: quat::Quaternion<f64>,
+}
+
+impl DummyPlatform {
+    fn new() -> Self { Self { pos: Vector3::zeros(), q: quat::id() } }
+}
+
+impl Platform for DummyPlatform {
+    fn update(&mut self, pos: Vector3<f64>, orient: quat::Quaternion<f64>) {
+        self.pos = pos; self.q = orient;
+    }
+    fn compute_angles(&self) -> Option<Vec<f64>> { Some(vec![0.0;6]) }
+    fn orientation(&self) -> quat::Quaternion<f64> { self.q }
+    fn translation(&self) -> Vector3<f64> { self.pos }
+}
+
+#[test]
+fn compare_with_js() {
+    let output = Command::new("node").arg("tests/js_workspace_call.mjs").output().expect("run js");
+    let js_result: stewart_sim::WorkspaceResult = from_slice(&output.stdout).expect("parse js");
+
+    let mut platform = DummyPlatform::new();
+    let mut ranges = Ranges::new();
+    ranges.insert("x".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    ranges.insert("y".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    ranges.insert("z".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    ranges.insert("rx".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    ranges.insert("ry".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    ranges.insert("rz".into(), Range { min: 0.0, max: 0.0, step: 1.0 });
+    let rust_result = compute_workspace(&mut platform, &ranges, WorkspaceOptions::default());
+    assert_eq!(js_result.coverage, rust_result.coverage);
+    assert_eq!(js_result.reachable.len(), rust_result.reachable.len());
+    assert_eq!(js_result.unreachable.len(), rust_result.unreachable.len());
+}


### PR DESCRIPTION
## Summary
- add Rust workspace sweep with quaternion and nalgebra math
- implement genetic optimizer in Rust mirroring JS logic
- compare Rust workspace results to JavaScript via unit test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c7245775ec8331863f142e07601fd0