### PR TITLE
Add Windows cross-compilation script and CI workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: build-windows
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: x86_64-pc-windows-gnu
+          profile: minimal
+      - name: Install mingw-w64
+        run: sudo apt-get update && sudo apt-get install -y mingw-w64
+      - name: Build and bundle
+        run: ./scripts/build-windows.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: stewart-sim-windows
+          path: dist/windows

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+target/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Custom Simulator
+
+This project contains a Rust application along with web assets.
+
+## Prerequisites
+- [Rust](https://www.rust-lang.org/tools/install) with `cargo`
+- Windows target: `rustup target add x86_64-pc-windows-gnu`
+- MinGW toolchain (`mingw-w64`) for linking
+
+## Building
+To cross-compile a Windows `.exe` and bundle assets, run:
+
+```bash
+./scripts/build-windows.sh
+```
+
+The bundled binary and resources will be in `dist/windows/`.
+
+To run the build manually without the script:
+
+```bash
+cargo build --release --target x86_64-pc-windows-gnu --manifest-path stewart_sim/Cargo.toml
+```
+
+## Continuous Integration
+GitHub Actions configuration at `.github/workflows/build.yml` automatically builds the Windows executable and uploads it as a workflow artifact for each push or pull request.

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build Windows binary
+rustup target add x86_64-pc-windows-gnu >/dev/null 2>&1 || true
+cargo build --release --target x86_64-pc-windows-gnu --manifest-path stewart_sim/Cargo.toml
+
+# Bundle assets
+DIST_DIR="dist/windows"
+rm -rf "$DIST_DIR"
+mkdir -p "$DIST_DIR"
+cp stewart_sim/target/x86_64-pc-windows-gnu/release/stewart_sim.exe "$DIST_DIR/"
+cp index.html workspace.js optimizer.js "$DIST_DIR/"
+cp -r "Raw Information" "$DIST_DIR/" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- configure Windows cross-compilation linker
- add build script to bundle binary and assets
- document build prerequisites and add CI to upload Windows artifacts

## Testing
- `./scripts/build-windows.sh`
- `cargo test --manifest-path stewart_sim/Cargo.toml`


------
https://chatgpt.com/codex/tasks/task_b_68c72d7d1838833185c8d71acc2b0af2