### PR TITLE
Preserve platform methods during optimization

### DIFF
--- a/optimizer.js
+++ b/optimizer.js
@@ -159,7 +159,12 @@ export class Optimizer {
 
   /** Evaluate objectives of a layout */
   async evaluateLayout(layout) {
-    const ws = await computeWorkspace({ ...this.platform, ...layout }, this.ranges, {
+    const platformClone = Object.assign(
+      Object.create(Object.getPrototypeOf(this.platform)),
+      this.platform,
+      layout
+    );
+    const ws = await computeWorkspace(platformClone, this.ranges, {
       payload: this.payload,
       stroke: this.stroke,
       frequency: this.frequency,


### PR DESCRIPTION
## Summary
- Clone platform with its prototype in `evaluateLayout` so workspace computation retains platform methods

## Testing
- `npm test` (fails: Error: no test specified)
- `node --input-type=module` sample run verifying optimizer completes 2 generations and reports coverage


------
https://chatgpt.com/codex/tasks/task_b_68c743cda7d08331abb490017f0f91ad