### PR TITLE
Handle optimizer step errors gracefully

### DIFF
--- a/Raw Information/index_linear_example.html
+++ b/Raw Information/index_linear_example.html
@@ -1780,7 +1780,12 @@ Stewart.prototype.initLinear = function (opts) {
                 optStatus.textContent = `Generation ${currentOptimizer.generation}/${currentOptimizer.generations}`;
                 if (currentOptimizer.running) requestAnimationFrame(update);
             };
-            currentOptimizer.start(() => {
+            currentOptimizer.start((err) => {
+                if (err) {
+                    console.error(err);
+                    optStatus.textContent = 'Error';
+                    return;
+                }
                 const best = currentOptimizer.fitness[0];
                 optStatus.textContent = `Done. Coverage ${(best.coverage * 100).toFixed(1)}%`;
             });

--- a/index.html
+++ b/index.html
@@ -1853,7 +1853,12 @@ Stewart.prototype.initAyva = function (opts) {
                 optStatus.textContent = `Generation ${currentOptimizer.generation}/${currentOptimizer.generations}`;
                 if (currentOptimizer.running) requestAnimationFrame(update);
             };
-            currentOptimizer.start(() => {
+            currentOptimizer.start((err) => {
+                if (err) {
+                    console.error(err);
+                    optStatus.textContent = 'Error';
+                    return;
+                }
                 const best = currentOptimizer.fitness[0];
                 optStatus.textContent = `Done. Coverage ${(best.coverage * 100).toFixed(1)}%`;
             });

--- a/optimizer.js
+++ b/optimizer.js
@@ -298,9 +298,16 @@ export class Optimizer {
     this.running = true;
     const run = async () => {
       if (!this.running || this.generation >= this.generations) {
-        this.running = false; if (callback) callback(this); return; }
-      await this.step();
-      setTimeout(run, 0);
+        this.running = false; if (callback) callback(null, this); return; }
+      try {
+        await this.step();
+        setTimeout(run, 0);
+      } catch (err) {
+        this.running = false;
+        console.error(err);
+        this.lastError = err;
+        if (callback) callback(err, this); else throw err;
+      }
     };
     run();
   }


### PR DESCRIPTION
## Summary
- wrap `await this.step()` in optimizer start loop with try/catch
- stop optimizer and log error, surfacing via callback
- update UI callbacks to display optimization errors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c7579b22048331a27ada63016c5e8f