### PR TITLE
feat: add wasm build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron .",
-    "dist": "electron-builder --win"
+    "dist": "electron-builder --win",
+    "build:wasm": "wasm-pack build stewart_sim --release --target nodejs --features wasm"
   },
   "keywords": [],
   "author": "",

--- a/stewart_sim/Cargo.lock
+++ b/stewart_sim/Cargo.lock
@@ -1463,9 +1463,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.5+wasi-0.2.4",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3638,6 +3640,7 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "eframe",
+ "getrandom 0.3.3",
  "nalgebra",
  "quaternion",
  "rand",

--- a/stewart_sim/Cargo.toml
+++ b/stewart_sim/Cargo.toml
@@ -11,6 +11,8 @@ rand = "0.9.2"
 serde = { version = "1.0.223", features = ["derive"] }
 serde_json = "1.0.145"
 three-d = { version = "0.18.2", features = ["egui-gui", "window"] }
+getrandom = { version = "0.3", features = ["wasm_js"], optional = true }
+wasm-bindgen = { version = "0.2", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -22,3 +24,7 @@ harness = false
 [[bench]]
 name = "optimizer"
 harness = false
+
+[features]
+default = []
+wasm = ["getrandom", "wasm-bindgen"]


### PR DESCRIPTION
## Summary
- allow stewart_sim crate to compile to WebAssembly via wasm-bindgen
- expose `npm run build:wasm` to generate NodeJS-ready wasm package

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68c76828d6408331b2315508a1d4b857