### PR TITLE
Resolve merge conflicts for wasm build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist/
 target/
+node_modules/

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron .",
     "dist": "electron-builder --win",
-    "build:wasm": "wasm-pack build stewart_sim --release --target nodejs --features wasm"
+    "build:wasm": "wasm-pack build stewart_sim --release --target nodejs --features wasm --locked",
+    "optimize:demo": "node -e \"(async () => { const m = await import('./wasm_optimizer.js'); console.log(await m.optimize()); })();\""
   },
   "keywords": [],
   "author": "",

--- a/stewart_sim/Cargo.lock
+++ b/stewart_sim/Cargo.lock
@@ -768,6 +768,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,6 +3648,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stewart_sim"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "criterion",
  "eframe",
  "getrandom 0.3.3",
@@ -3645,8 +3656,10 @@ dependencies = [
  "quaternion",
  "rand",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "three-d",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4083,6 +4096,8 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
+ "serde_json",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]

--- a/stewart_sim/Cargo.toml
+++ b/stewart_sim/Cargo.toml
@@ -3,6 +3,9 @@ name = "stewart_sim"
 version = "0.1.0"
 edition = "2024"
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 eframe = "0.32"
 nalgebra = "0.34.0"
@@ -12,7 +15,9 @@ serde = { version = "1.0.223", features = ["derive"] }
 serde_json = "1.0.145"
 three-d = { version = "0.18.2", features = ["egui-gui", "window"] }
 getrandom = { version = "0.3", features = ["wasm_js"], optional = true }
-wasm-bindgen = { version = "0.2", optional = true }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
@@ -27,4 +32,7 @@ harness = false
 
 [features]
 default = []
-wasm = ["getrandom", "wasm-bindgen"]
+wasm = ["getrandom", "wasm-bindgen", "console_error_panic_hook", "serde-wasm-bindgen"]
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false


### PR DESCRIPTION
## Summary
- lock wasm build and add optimize demo script
- enable extra wasm dependencies and disable wasm-opt in Cargo.toml
- ignore node_modules directory

## Testing
- `npm test` (fails: no test specified)
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_b_68c7845722308331a851c3ef4630a78e