### PR TITLE
Stop committing wasm artifacts and build them during packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 target/
 node_modules/
+stewart_sim/pkg/*.wasm

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "electron .",
+    "predist": "npm run build:wasm",
     "dist": "electron-builder --win",
     "build:wasm": "wasm-pack build stewart_sim --release --target nodejs --features wasm --locked",
     "optimize:demo": "node -e \"(async () => { const m = await import('./wasm_optimizer.js'); console.log(await m.optimize()); })();\""

--- a/scripts/build-windows.sh
+++ b/scripts/build-windows.sh
@@ -5,10 +5,14 @@ set -euo pipefail
 rustup target add x86_64-pc-windows-gnu >/dev/null 2>&1 || true
 cargo build --release --target x86_64-pc-windows-gnu --manifest-path stewart_sim/Cargo.toml
 
+# Build the WebAssembly package so the runtime bindings are available
+npm run build:wasm
+
 # Bundle assets
 DIST_DIR="dist/windows"
 rm -rf "$DIST_DIR"
 mkdir -p "$DIST_DIR"
 cp stewart_sim/target/x86_64-pc-windows-gnu/release/stewart_sim.exe "$DIST_DIR/"
 cp index.html workspace.js optimizer.js "$DIST_DIR/"
+cp -r stewart_sim/pkg "$DIST_DIR/stewart_sim/"
 cp -r "Raw Information" "$DIST_DIR/" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ignore wasm artifacts generated by wasm-pack
- build the wasm package as part of the Windows bundle script and include the generated bindings
- hook the wasm build into the distribution npm script so the binary is created on demand

## Testing
- npm run build:wasm *(fails: wasm-pack is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9e2af66748331a622be162ff5aebd