### PR TITLE
Add wasm-pack installation and replace optimizer RNG for WASM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
           profile: minimal
       - name: Install mingw-w64
         run: sudo apt-get update && sudo apt-get install -y mingw-w64
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
       - name: Build and bundle
         run: ./scripts/build-windows.sh
       - name: Upload artifact

--- a/stewart_sim/Cargo.lock
+++ b/stewart_sim/Cargo.lock
@@ -1473,11 +1473,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.5+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3092,15 +3090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "presser"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3197,35 +3186,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
-dependencies = [
- "getrandom 0.3.3",
-]
 
 [[package]]
 name = "range-alloc"
@@ -3651,10 +3611,9 @@ dependencies = [
  "console_error_panic_hook",
  "criterion",
  "eframe",
- "getrandom 0.3.3",
+ "fastrand",
  "nalgebra",
  "quaternion",
- "rand",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/stewart_sim/Cargo.toml
+++ b/stewart_sim/Cargo.toml
@@ -8,13 +8,12 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 eframe = "0.32"
+fastrand = "2.0"
 nalgebra = "0.34.0"
 quaternion = "2.0.0"
-rand = "0.9.2"
 serde = { version = "1.0.223", features = ["derive"] }
 serde_json = "1.0.145"
 three-d = { version = "0.18.2", features = ["egui-gui", "window"] }
-getrandom = { version = "0.3", features = ["wasm_js"], optional = true }
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"], optional = true }
 console_error_panic_hook = { version = "0.1.7", optional = true }
 serde-wasm-bindgen = { version = "0.6", optional = true }
@@ -32,7 +31,7 @@ harness = false
 
 [features]
 default = []
-wasm = ["getrandom", "wasm-bindgen", "console_error_panic_hook", "serde-wasm-bindgen"]
+wasm = ["wasm-bindgen", "console_error_panic_hook", "serde-wasm-bindgen"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/stewart_sim/src/optimizer.rs
+++ b/stewart_sim/src/optimizer.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use fastrand::Rng;
 use serde::{Deserialize, Serialize};
 
 use crate::workspace::{compute_workspace, Platform, Ranges, WorkspaceOptions, WorkspaceResult};
@@ -24,7 +24,7 @@ pub struct Optimizer<P: ConfigurablePlatform> {
     pub generations: usize,
     pub mutation_rate: f64,
     pub population: Vec<Layout>,
-    rng: rand::rngs::ThreadRng,
+    rng: Rng,
 }
 
 impl<P: ConfigurablePlatform> Optimizer<P> {
@@ -37,12 +37,12 @@ impl<P: ConfigurablePlatform> Optimizer<P> {
             generations,
             mutation_rate,
             population: Vec::new(),
-            rng: rand::rng(),
+            rng: Rng::new(),
         }
     }
 
     fn randomize_layout(&mut self, base: &Layout) -> Layout {
-        let mut rand_val = |v: f64| v + (self.rng.random_range(0.0..1.0) * 2.0 - 1.0) * 5.0;
+        let mut rand_val = |v: f64| v + (self.rng.f64() * 2.0 - 1.0) * 5.0;
         Layout { horn_length: rand_val(base.horn_length), rod_length: rand_val(base.rod_length) }
     }
 
@@ -58,8 +58,8 @@ impl<P: ConfigurablePlatform> Optimizer<P> {
 
     fn mutate(&mut self, layout: &mut Layout) {
         let mut rand_val = |v: &mut f64| {
-            if self.rng.random_range(0.0..1.0) < self.mutation_rate {
-                *v += (self.rng.random_range(0.0..1.0) * 2.0 - 1.0) * 5.0;
+            if self.rng.f64() < self.mutation_rate {
+                *v += (self.rng.f64() * 2.0 - 1.0) * 5.0;
             }
         };
         rand_val(&mut layout.horn_length);
@@ -81,7 +81,7 @@ impl<P: ConfigurablePlatform> Optimizer<P> {
             .collect();
         let mut new_pop = survivors.clone();
         while new_pop.len() < self.population_size {
-            let mut child = survivors[self.rng.random_range(0..survivors.len())].clone();
+            let mut child = survivors[self.rng.usize(0..survivors.len())].clone();
             self.mutate(&mut child);
             new_pop.push(child);
         }


### PR DESCRIPTION
## Summary
- install wasm-pack before the build step in the Windows workflow so wasm tooling is available
- replace the optimizer's use of `rand` with `fastrand` and drop the extra `getrandom` dependency to keep wasm builds working

## Testing
- cargo build --manifest-path stewart_sim/Cargo.toml
- npm run build:wasm

------
https://chatgpt.com/codex/tasks/task_b_68c9eeb625448331affc34b649dae5e6